### PR TITLE
Fix/WIKI-1457: Saml2 Wiki Encoding Issue

### DIFF
--- a/saml/gatein-saml-plugin/src/main/java/org/gatein/sso/saml/plugin/filter/SAML2LogoutFilter.java
+++ b/saml/gatein-saml-plugin/src/main/java/org/gatein/sso/saml/plugin/filter/SAML2LogoutFilter.java
@@ -69,7 +69,7 @@ public class SAML2LogoutFilter extends SPFilter implements SSOInterceptor {
                        FilterChain filterChain) throws IOException, ServletException {
     HttpServletRequest request = (HttpServletRequest) servletRequest;
     HttpServletResponse response = (HttpServletResponse) servletResponse;
-
+    request.setCharacterEncoding("UTF-8");
     if (isPortalLogoutInProgress(request)) {
       if(StringUtils.isBlank(getPortalLogoutURLFromSession(request))) {
         // Step 1 : Begin -  call logout action


### PR DESCRIPTION
eXo as SAML Service Provider produced an Encoding issue with special characters on wiki pages. This was probably due to the default encoding **ISO-8859-1**. I persisted the CharacterEncoding as **UTF-8** of the Servlet Request on doFilter() method.
